### PR TITLE
create channel api

### DIFF
--- a/cassettes/open_discussions_api.channels.client_test.test_create_channel.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_channel.json
@@ -1,0 +1,76 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-09-05T16:05:18",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"title\": \"new test channel\", \"name\": \"examplechannel\", \"public_description\": \"a good channel for all things\", \"channel_type\": \"public\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFsaWNlIiwicm9sZXMiOlsic3RhZmYiXSwiZXhwIjoxNTA0NjMxMTE3LCJvcmlnX2lhdCI6MTUwNDYyNzUxN30._wbyMW6weSfDL6yyxeDpkqkHOYum87EjG8DmZ1lAj60"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "136"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ]
+        },
+        "method": "POST",
+        "uri": "http://localhost:8063/api/v0/channels/"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"title\":\"new test channel\",\"name\":\"examplechannel\",\"public_description\":\"a good channel for all things\",\"channel_type\":\"public\"}"
+        },
+        "headers": {
+          "Allow": [
+            "GET, POST, HEAD, OPTIONS"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 05 Sep 2017 16:05:18 GMT"
+          ],
+          "Server": [
+            "nginx/1.11.9"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ]
+        },
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "url": "http://localhost:8063/api/v0/channels/"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/open_discussions_api.channels.client_test.test_create_channel_with_bad_channel_type.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_channel_with_bad_channel_type.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/open_discussions_api.channels.client_test.test_create_channel_with_no_arguments.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_channel_with_no_arguments.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/open_discussions_api.channels.client_test.test_create_channel_with_unsupported_args.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_channel_with_unsupported_args.json
@@ -1,0 +1,4 @@
+{
+  "http_interactions": [],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/open_discussions_api.channels.client_test.test_create_private_channel.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_private_channel.json
@@ -1,0 +1,76 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-09-05T16:17:53",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"title\": \"new private channel\", \"name\": \"privatechannel\", \"public_description\": \"a good channel for all things\", \"channel_type\": \"private\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6ImFsaWNlIiwicm9sZXMiOlsic3RhZmYiXSwiZXhwIjoxNTA0NjMxODczLCJvcmlnX2lhdCI6MTUwNDYyODI3M30.7lOkPRkEe8Dk7cD965M64Iu7LEQY0-_Q3m0rxHmbwrs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "140"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ]
+        },
+        "method": "POST",
+        "uri": "http://localhost:8063/api/v0/channels/"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"title\":\"new private channel\",\"name\":\"privatechannel\",\"public_description\":\"a good channel for all things\",\"channel_type\":\"private\"}"
+        },
+        "headers": {
+          "Allow": [
+            "GET, POST, HEAD, OPTIONS"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Tue, 05 Sep 2017 16:17:53 GMT"
+          ],
+          "Server": [
+            "nginx/1.11.9"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ]
+        },
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "url": "http://localhost:8063/api/v0/channels/"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/open_discussions_api/channels/client.py
+++ b/open_discussions_api/channels/client.py
@@ -1,0 +1,41 @@
+"""Channels API"""
+from open_discussions_api.base import BaseApi
+from open_discussions_api.channels.constants import CHANNEL_ATTRIBUTES, VALID_CHANNEL_TYPES
+
+
+class EmptyAttributesError(AttributeError):
+    """Error for empty attributes"""
+    pass
+
+
+class UnsupportedAttributeError(AttributeError):
+    """Error for an unsupported attribute"""
+    pass
+
+
+class InvalidChannelTypeError(AttributeError):
+    """Error for invalid channel type"""
+    pass
+
+
+class ChannelsApi(BaseApi):
+    """Channels API"""
+
+    def create(self, **channel_params):
+        """create a new channel"""
+        if not channel_params:
+            raise EmptyAttributesError()
+
+        for key in channel_params:
+            if key not in CHANNEL_ATTRIBUTES:
+                raise UnsupportedAttributeError("Argument '{}' is not a supported field".format(key))
+
+        if channel_params['channel_type'] not in VALID_CHANNEL_TYPES:
+            raise InvalidChannelTypeError(
+                "Channel type '{}' is not a valid option".format(channel_params['channel_type'])
+            )
+
+        return self.session.post(
+            self.get_url("/channels/"),
+            json=channel_params
+        )

--- a/open_discussions_api/channels/client_test.py
+++ b/open_discussions_api/channels/client_test.py
@@ -1,0 +1,80 @@
+"""Tests for user client API"""
+import json
+import pytest
+
+from open_discussions_api.channels.client import (
+    EmptyAttributesError,
+    UnsupportedAttributeError,
+    InvalidChannelTypeError
+)
+
+
+def test_create_channel(api_client):
+    """test a happpy path"""
+    resp = api_client.channels.create(
+        title="new test channel",
+        name="examplechannel",
+        public_description="a good channel for all things",
+        channel_type="public"
+    )
+    assert resp.status_code == 201
+    assert json.loads(resp.request.body) == {
+        "title": "new test channel",
+        "name": "examplechannel",
+        "public_description": "a good channel for all things",
+        "channel_type": "public"
+    }
+    assert resp.json() == {
+        "title": "new test channel",
+        "name": "examplechannel",
+        "public_description": "a good channel for all things",
+        "channel_type": "public"
+    }
+
+
+def test_create_private_channel(api_client):
+    """test a different happy path"""
+    resp = api_client.channels.create(
+        title="new private channel",
+        name="privatechannel",
+        public_description="a good channel for all things",
+        channel_type="private"
+    )
+    assert resp.status_code == 201
+    assert json.loads(resp.request.body) == {
+        "title": "new private channel",
+        "name": "privatechannel",
+        "public_description": "a good channel for all things",
+        "channel_type": "private"
+    }
+    assert resp.json() == {
+        "title": "new private channel",
+        "name": "privatechannel",
+        "public_description": "a good channel for all things",
+        "channel_type": "private"
+    }
+
+
+def test_create_channel_with_no_arguments(api_client):
+    """should raise when provided nothing"""
+    with pytest.raises(EmptyAttributesError):
+        api_client.channels.create()
+
+
+def test_create_channel_with_unsupported_args(api_client):
+    """should raise if you pass a bad param"""
+    with pytest.raises(UnsupportedAttributeError) as err:
+        api_client.channels.create(bad="wrong")
+    assert str(err.value) == "Argument 'bad' is not a supported field"
+
+
+def test_create_channel_with_bad_channel_type(api_client):
+    """should raise if you pass something unsupported"""
+    with pytest.raises(InvalidChannelTypeError) as err:
+        api_client.channels.create(
+            title="new private channel",
+            name="privatechannel",
+            public_description="a good channel for all things",
+            channel_type="fun"
+        )
+    assert str(err.value) == "Channel type 'fun' is not a valid option"

--- a/open_discussions_api/channels/constants.py
+++ b/open_discussions_api/channels/constants.py
@@ -1,0 +1,13 @@
+"""constants"""
+CHANNEL_ATTRIBUTES = [
+    "title",
+    "name",
+    "public_description",
+    "channel_type",
+]
+
+
+VALID_CHANNEL_TYPES = [
+    'public',
+    'private'
+]

--- a/open_discussions_api/client.py
+++ b/open_discussions_api/client.py
@@ -3,6 +3,7 @@ import requests
 
 from open_discussions_api.users.client import UsersApi
 from open_discussions_api.utils import get_token
+from open_discussions_api.channels.client import ChannelsApi
 
 
 class OpenDiscussionsApi(object):
@@ -63,3 +64,10 @@ class OpenDiscussionsApi(object):
             open_discussions_api.users.client.UsersApi: configured users api
         """
         return UsersApi(self._get_authenticated_session(), self.base_url, self.version)
+
+    @property
+    def channels(self):
+        """
+        Channels API
+        """
+        return ChannelsApi(self._get_authenticated_session(), self.base_url, self.version)


### PR DESCRIPTION
#### What are the relevant tickets?

#2 

#### What's this PR do?

adds the ability to create channels

#### How should this be manually tested?

this should do it

```py
from open_discussions_api.client import OpenDiscussionsApi

# replace 'mitodl' with your username for OD
api = OpenDiscussionsApi('terribly_unsafe_default_jwt_secret_key','http://localhost:8063/', 'mitodl', roles=['staff'])

api.channels.create(
  title="new test channel",
  name="namenewtestchannel",
  public_description="a good channel for all things",
  channel_type="public"
)
```