### PR TITLE
Added extra_payload arg to get_token

### DIFF
--- a/open_discussions_api/utils.py
+++ b/open_discussions_api/utils.py
@@ -6,7 +6,7 @@ import jwt
 EXPIRATION_DELTA_SECONDS = 60 * 60
 
 
-def get_token(secret, username, roles, expires_delta=EXPIRATION_DELTA_SECONDS):
+def get_token(secret, username, roles, expires_delta=EXPIRATION_DELTA_SECONDS, extra_payload=None):
     """
     Gets a JWt token
 
@@ -14,14 +14,23 @@ def get_token(secret, username, roles, expires_delta=EXPIRATION_DELTA_SECONDS):
         username (str): user's username
         roles (list(str)): list of roles
         expires_delta (int): offset in second of token expiration
+        extra_payload (dict): dictionary of extra payload properties to encode in the token
 
     Returns:
         str: encoded JWT token
     """
     now = int(time.time())
-    return jwt.encode({
+    payload = {
         'username': username,
         'roles': roles,
         'exp': now + expires_delta,
         'orig_iat': now,
-    }, secret, algorithm='HS256').decode('utf-8')
+    }
+
+    invalid_extras = set(payload).intersection(extra_payload or {})
+    if invalid_extras:
+        raise AttributeError('Invalid arguments for payload: {}'.format(invalid_extras))
+
+    if extra_payload:
+        payload.update(extra_payload)
+    return jwt.encode(payload, secret, algorithm='HS256').decode('utf-8')

--- a/open_discussions_api/utils_test.py
+++ b/open_discussions_api/utils_test.py
@@ -1,13 +1,35 @@
 """Tests for api utils"""
 import jwt
+import pytest
 
 from open_discussions_api.utils import get_token
 
 
 def test_get_token():
     """Test that get_token encodes a token decodable by the secret"""
-    token = get_token('secret', 'username', ['test_role'], expires_delta=100)
+    token = get_token(
+        'secret',
+        'username',
+        ['test_role'],
+        expires_delta=100,
+        extra_payload=dict(auth_url='auth', session_url='session')
+    )
     decoded = jwt.decode(token, 'secret', algorithms=['HS256'])
     assert decoded['username'] == 'username'
     assert decoded['roles'] == ['test_role']
     assert decoded['exp'] == decoded['orig_iat'] + 100
+    assert decoded['auth_url'] == 'auth'
+    assert decoded['session_url'] == 'session'
+
+
+def test_get_token_error():
+    """Test that get_token raises an ArgumentError if a bad extra_payload arg is passed"""
+
+    with pytest.raises(AttributeError):
+        get_token(
+            'secret',
+            'username',
+            ['test_role'],
+            expires_delta=100,
+            extra_payload=dict(auth_url='auth', username='username')  # username is a default item in the payload
+        )


### PR DESCRIPTION
#### What are the relevant tickets?
Part of mitodl/open-discussions#153

#### What's this PR do?
Adds an `extra_payload` arg so we can pass extra stuff to the payload token (e.g. session timeout urls, etc)

#### How should this be manually tested?
Tests should pass
