### PR TITLE
Add add_contributor and remove_contributor

### DIFF
--- a/cassettes/open_discussions_api.channels.client_test.test_add_contributor.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_add_contributor.json
@@ -1,0 +1,76 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-09-11T18:17:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"contributor_name\": \"01BSRT7XMQT33SCNKTYTSES5QQ\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6Imdlb3JnZSIsIm9yaWdfaWF0IjoxNTA1MTUzODUzLCJleHAiOjE1MDUxNTc0NTMsInJvbGVzIjpbInN0YWZmIl19.ajtCBYJJUkBAVTzqfGzawXyxNSIxS5OqGFy-O1GdC1g"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "50"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ]
+        },
+        "method": "POST",
+        "uri": "http://localhost:8063/api/v0/channels/a_channel/contributors/"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"contributor_name\":\"01BSRT7XMQT33SCNKTYTSES5QQ\"}"
+        },
+        "headers": {
+          "Allow": [
+            "GET, POST, HEAD, OPTIONS"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Mon, 11 Sep 2017 18:17:33 GMT"
+          ],
+          "Server": [
+            "nginx/1.11.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ]
+        },
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "url": "http://localhost:8063/api/v0/channels/a_channel/contributors/"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/open_discussions_api.channels.client_test.test_remove_contributor.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_remove_contributor.json
@@ -1,0 +1,70 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-09-11T18:26:51",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6Imdlb3JnZSIsIm9yaWdfaWF0IjoxNTA1MTU0NDEwLCJleHAiOjE1MDUxNTgwMTAsInJvbGVzIjpbInN0YWZmIl19.OWz6l87qR23x32mdcXbFft0EVaobFlTIWlRe6_3qdeA"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ]
+        },
+        "method": "DELETE",
+        "uri": "http://localhost:8063/api/v0/channels/a_channel/contributors/01BSRT7XMQT33SCNKTYTSES5QQ/"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Allow": [
+            "GET, DELETE, HEAD, OPTIONS"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Date": [
+            "Mon, 11 Sep 2017 18:26:51 GMT"
+          ],
+          "Server": [
+            "nginx/1.11.6"
+          ],
+          "Vary": [
+            "Accept"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ]
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "http://localhost:8063/api/v0/channels/a_channel/contributors/01BSRT7XMQT33SCNKTYTSES5QQ/"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/open_discussions_api/betamax_config.py
+++ b/open_discussions_api/betamax_config.py
@@ -24,7 +24,7 @@ def _parse_request_body(request):
 
 
 class CustomBodyMatcher(BodyMatcher):
-    """Override BodyMatcher to skip OAuth body checks, and compare JSON if applicable"""
+    """Override BodyMatcher to convert str to bytes and compare JSON if applicable"""
 
     name = 'custom-body'
 
@@ -33,10 +33,6 @@ class CustomBodyMatcher(BodyMatcher):
 
         request_body = _parse_request_body(request)
         recorded_body = _parse_request_body(recorded_request)
-
-        # Don't check body for oauth workflow
-        if request.url.endswith('api/v1/access_token'):
-            return True
 
         return recorded_body == request_body
 

--- a/open_discussions_api/betamax_config.py
+++ b/open_discussions_api/betamax_config.py
@@ -1,13 +1,52 @@
 """Configuration for betamax"""
+import json
+
 from betamax import Betamax
+from betamax.util import deserialize_prepared_request
+from betamax.matchers.body import BodyMatcher
 from betamax_serializers.pretty_json import PrettyJSONSerializer
+
+
+def _parse_request_body(request):
+    """Parse the JSON from the request body, or return its bytes"""
+    body = request.body
+    if not body:
+        return b''
+
+    if request.headers.get("Content-Type") == "application/json":
+        if isinstance(body, bytes):
+            return json.loads(body.decode())
+        return json.loads(body)
+
+    if isinstance(body, str):
+        return body.encode()
+    return body
+
+
+class CustomBodyMatcher(BodyMatcher):
+    """Override BodyMatcher to skip OAuth body checks, and compare JSON if applicable"""
+
+    name = 'custom-body'
+
+    def match(self, request, recorded_request):
+        recorded_request = deserialize_prepared_request(recorded_request)
+
+        request_body = _parse_request_body(request)
+        recorded_body = _parse_request_body(recorded_request)
+
+        # Don't check body for oauth workflow
+        if request.url.endswith('api/v1/access_token'):
+            return True
+
+        return recorded_body == request_body
 
 
 def setup_betamax():
     """Do global configuration for betamax. This function is idempotent."""
+    Betamax.register_request_matcher(CustomBodyMatcher)
     Betamax.register_serializer(PrettyJSONSerializer)
 
     config = Betamax.configure()
     config.cassette_library_dir = "cassettes"
-    config.default_cassette_options['match_requests_on'] = ['uri', 'method']
+    config.default_cassette_options['match_requests_on'] = ['uri', 'method', 'custom-body']
     config.default_cassette_options['serialize_with'] = 'prettyjson'

--- a/open_discussions_api/channels/client.py
+++ b/open_discussions_api/channels/client.py
@@ -1,4 +1,6 @@
 """Channels API"""
+from urllib.parse import quote
+
 from open_discussions_api.base import BaseApi
 from open_discussions_api.channels.constants import CHANNEL_ATTRIBUTES, VALID_CHANNEL_TYPES
 
@@ -38,4 +40,26 @@ class ChannelsApi(BaseApi):
         return self.session.post(
             self.get_url("/channels/"),
             json=channel_params
+        )
+
+    def add_contributor(self, channel_name, username):
+        """Add a contributor to a channel"""
+
+        return self.session.post(
+            self.get_url("/channels/{channel_name}/contributors/".format(
+                channel_name=quote(channel_name),
+            )),
+            json={"contributor_name": username}
+        )
+
+    def remove_contributor(self, channel_name, username):
+        """
+        Remove a contributor from a channel
+        """
+
+        return self.session.delete(
+            self.get_url("/channels/{channel_name}/contributors/{username}/".format(
+                channel_name=quote(channel_name),
+                username=quote(username),
+            ))
         )

--- a/open_discussions_api/channels/client.py
+++ b/open_discussions_api/channels/client.py
@@ -24,7 +24,18 @@ class ChannelsApi(BaseApi):
     """Channels API"""
 
     def create(self, **channel_params):
-        """create a new channel"""
+        """
+        Create a new channel
+
+        Args:
+            channel_params (dict):
+                Attributes used in creation of the channel, see CHANNEL_ATTRIBUTES for a list
+
+        Returns:
+            requests.Response:
+                The response to the channel creation. If successful it contains the payload with
+                the new channel's parameters.
+        """
         if not channel_params:
             raise EmptyAttributesError()
 
@@ -43,7 +54,18 @@ class ChannelsApi(BaseApi):
         )
 
     def add_contributor(self, channel_name, username):
-        """Add a contributor to a channel"""
+        """
+        Add a contributor to a channel
+
+        Args:
+            channel_name (str): The name of the channel
+            username (str): The username of the contributor
+
+        Returns:
+            requests.Response:
+                The response of the request to add a contributor. This should only
+                contain the contributor's username in its payload, similar to the request payload.
+        """
 
         return self.session.post(
             self.get_url("/channels/{channel_name}/contributors/".format(
@@ -55,6 +77,13 @@ class ChannelsApi(BaseApi):
     def remove_contributor(self, channel_name, username):
         """
         Remove a contributor from a channel
+
+        Args:
+            channel_name (str): The name of the channel
+            username (str): The username of the contributor to be removed
+
+        Returns:
+            requests.Response: The response of the request to delete the contributor
         """
 
         return self.session.delete(

--- a/open_discussions_api/channels/client_test.py
+++ b/open_discussions_api/channels/client_test.py
@@ -78,3 +78,18 @@ def test_create_channel_with_bad_channel_type(api_client):
             channel_type="fun"
         )
     assert str(err.value) == "Channel type 'fun' is not a valid option"
+
+
+def test_add_contributor(api_client):
+    """This should add one contributor to a channel"""
+    resp = api_client.channels.add_contributor("a_channel", "01BSRT7XMQT33SCNKTYTSES5QQ")
+    assert resp.status_code == 201
+    assert resp.json() == {
+        "contributor_name": "01BSRT7XMQT33SCNKTYTSES5QQ"
+    }
+
+
+def test_remove_contributor(api_client):
+    """This should remove a contributor to a channel"""
+    resp = api_client.channels.remove_contributor("a_channel", "01BSRT7XMQT33SCNKTYTSES5QQ")
+    assert resp.status_code == 204

--- a/open_discussions_api/recorder.py
+++ b/open_discussions_api/recorder.py
@@ -1,4 +1,4 @@
-"""Add context manager to make recording reddit requests simpler"""
+"""Add context manager to make recording open-discussion requests simpler"""
 from contextlib import contextmanager
 from unittest.mock import patch
 

--- a/open_discussions_api/users/client.py
+++ b/open_discussions_api/users/client.py
@@ -1,5 +1,5 @@
 """Users API"""
-import json
+from urllib.parse import quote
 
 from open_discussions_api.base import BaseApi
 
@@ -20,7 +20,7 @@ class UsersApi(BaseApi):
 
     def get(self, username):
         """Gets a specific user"""
-        return self.session.get(self.get_url("/users/{}").format(username))
+        return self.session.get(self.get_url("/users/{}").format(quote(username)))
 
     def create(self, **profile):
         """Creates a new user"""
@@ -33,7 +33,7 @@ class UsersApi(BaseApi):
 
         return self.session.post(
             self.get_url("/users/"),
-            data=json.dumps(dict(profile=profile or {}))
+            json=dict(profile=profile or {})
         )
 
     def update(self, username, **profile):
@@ -46,6 +46,6 @@ class UsersApi(BaseApi):
                 raise AttributeError("Argument {} is not supported".format(key))
 
         return self.session.patch(
-            self.get_url("/users/{}/".format(username)),
-            data=json.dumps(dict(profile=profile))
+            self.get_url("/users/{}/".format(quote(username))),
+            json=dict(profile=profile)
         )

--- a/open_discussions_api/users/client.py
+++ b/open_discussions_api/users/client.py
@@ -15,15 +15,36 @@ class UsersApi(BaseApi):
     """Users API"""
 
     def list(self):
-        """Returns a list of users"""
+        """
+        Returns a list of users
+
+        Returns:
+            requests.Response: A response containing the data for all users in open-discussions
+        """
         return self.session.get(self.get_url("/users/"))
 
     def get(self, username):
-        """Gets a specific user"""
-        return self.session.get(self.get_url("/users/{}").format(quote(username)))
+        """
+        Gets a specific user
+
+        Args:
+            username (str): The username for the user
+
+        Returns:
+            requests.Response: A response containing the user's data
+        """
+        return self.session.get(self.get_url("/users/{}/").format(quote(username)))
 
     def create(self, **profile):
-        """Creates a new user"""
+        """
+        Creates a new user
+
+        Args:
+            profile (dict): attributes used in creating the profile. See SUPPORTED_USER_ATTRIBUTES for a list.
+
+        Returns:
+            requests.Response: A response containing the newly created profile data
+        """
         if not profile:
             raise AttributeError("No fields provided to create")
 
@@ -37,7 +58,17 @@ class UsersApi(BaseApi):
         )
 
     def update(self, username, **profile):
-        """Gets a specific user"""
+        """
+        Gets a specific user
+
+        Args:
+            username (str): The username of the user
+            profile (dict):
+                Attributes of the profile to update for that user. See SUPPORTED_USER_ATTRIBUTES for a valid list.
+
+        Returns:
+            requests.Response: A response containing the updated user profile data
+        """
         if not profile:
             raise AttributeError("No fields provided to update")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = --cov . --pep8 --pylint --cov-report term --cov-report html
-norecursedirs = .git .tox static templates .* CVS _darcs {arch} *.egg
+norecursedirs = build .git .tox static templates .* CVS _darcs {arch} *.egg
 pep8maxlinelength = 119
 filterwarnings =
     error


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #12 

#### What's this PR do?
Adds `add_contributor` and `remove_contributor` to interact with the endpoint `/api/v0/channels/<channel_name>/contributors/`

#### How should this be manually tested?
In a python shell run:

    from open_discussions_api.client import OpenDiscussionsApi
    api = OpenDiscussionsApi('terribly_unsafe_default_jwt_secret_key', 'http://localhost:8063/', 'staff_user', roles=['staff']) 
    api.channels.add_contributor('channel_name', 'username_goes_here')

You will need to replace `channel_name` with your own channel name, `staff_user` with a reddit user who owns `channel_name`, the jwt key if you're not using the default one, `localhost:8063` with the reddit URL if it's not already `localhost`, and `username_goes_here` should be some other reddit user which already exists.
