### PR TITLE
Added add_moderator and remove_moderator

### DIFF
--- a/cassettes/open_discussions_api.channels.client_test.test_add_moderator.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_add_moderator.json
@@ -1,0 +1,76 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-09-13T14:42:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"moderator_name\": \"01BSRT7XMQT33SCNKTYTSES5QQ\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJzdGFmZiJdLCJvcmlnX2lhdCI6MTUwNTMxMzczOCwiZXhwIjoxNTA1MzE3MzM4LCJ1c2VybmFtZSI6InJlZGRpdCJ9._REArmnLqagy6nlrHnR3BUjPozQClTbwpm17puBhyqI"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "48"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ]
+        },
+        "method": "POST",
+        "uri": "http://localhost:8063/api/v0/channels/a_channel/moderators/"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"moderator_name\":\"01BSRT7XMQT33SCNKTYTSES5QQ\"}"
+        },
+        "headers": {
+          "Allow": [
+            "GET, POST, HEAD, OPTIONS"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Wed, 13 Sep 2017 14:42:20 GMT"
+          ],
+          "Server": [
+            "nginx/1.11.6"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Vary": [
+            "Accept"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ]
+        },
+        "status": {
+          "code": 201,
+          "message": "Created"
+        },
+        "url": "http://localhost:8063/api/v0/channels/a_channel/moderators/"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/cassettes/open_discussions_api.channels.client_test.test_remove_moderator.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_remove_moderator.json
@@ -1,0 +1,70 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-09-13T14:42:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJzdGFmZiJdLCJvcmlnX2lhdCI6MTUwNTMxMzc0MCwiZXhwIjoxNTA1MzE3MzQwLCJ1c2VybmFtZSI6InJlZGRpdCJ9.Typsp3mwA51K8ILn7-azcr1XJ8c-LYUzi_GPHIKlVQc"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "User-Agent": [
+            "python-requests/2.18.4"
+          ]
+        },
+        "method": "DELETE",
+        "uri": "http://localhost:8063/api/v0/channels/a_channel/moderators/01BSRT7XMQT33SCNKTYTSES5QQ/"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": ""
+        },
+        "headers": {
+          "Allow": [
+            "GET, DELETE, HEAD, OPTIONS"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Date": [
+            "Wed, 13 Sep 2017 14:42:20 GMT"
+          ],
+          "Server": [
+            "nginx/1.11.6"
+          ],
+          "Vary": [
+            "Accept"
+          ],
+          "X-Frame-Options": [
+            "SAMEORIGIN"
+          ]
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "http://localhost:8063/api/v0/channels/a_channel/moderators/01BSRT7XMQT33SCNKTYTSES5QQ/"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/open_discussions_api/channels/client.py
+++ b/open_discussions_api/channels/client.py
@@ -92,3 +92,40 @@ class ChannelsApi(BaseApi):
                 username=quote(username),
             ))
         )
+
+    def add_moderator(self, channel_name, username):
+        """
+        Add a moderator to a channel
+
+        Args:
+            channel_name (str): The name of the channel
+            username (str): The name of the user to add as moderator
+
+        Returns:
+            requests.Response: The response of the request to add a moderator. This should only
+            contain the moderator username, the same which was passed in the request.
+        """
+        return self.session.post(
+            self.get_url("/channels/{channel_name}/moderators/".format(
+                channel_name=quote(channel_name)
+            )),
+            json={"moderator_name": username},
+        )
+
+    def remove_moderator(self, channel_name, username):
+        """
+        Remove a moderator from a channel
+
+        Args:
+            channel_name (str): The name of the channel
+            username (str): The name of the moderator to remove
+
+        Returns:
+            request.Response: The response of the request to remove the moderator
+        """
+        return self.session.delete(
+            self.get_url("/channels/{channel_name}/moderators/{username}/".format(
+                channel_name=quote(channel_name),
+                username=quote(username),
+            ))
+        )

--- a/open_discussions_api/channels/client_test.py
+++ b/open_discussions_api/channels/client_test.py
@@ -82,14 +82,31 @@ def test_create_channel_with_bad_channel_type(api_client):
 
 def test_add_contributor(api_client):
     """This should add one contributor to a channel"""
-    resp = api_client.channels.add_contributor("a_channel", "01BSRT7XMQT33SCNKTYTSES5QQ")
+    username = "01BSRT7XMQT33SCNKTYTSES5QQ"
+    resp = api_client.channels.add_contributor("a_channel", username)
     assert resp.status_code == 201
     assert resp.json() == {
-        "contributor_name": "01BSRT7XMQT33SCNKTYTSES5QQ"
+        "contributor_name": username
     }
 
 
 def test_remove_contributor(api_client):
     """This should remove a contributor to a channel"""
     resp = api_client.channels.remove_contributor("a_channel", "01BSRT7XMQT33SCNKTYTSES5QQ")
+    assert resp.status_code == 204
+
+
+def test_add_moderator(api_client):
+    """This should add one moderator to a channel"""
+    username = "01BSRT7XMQT33SCNKTYTSES5QQ"
+    resp = api_client.channels.add_moderator("a_channel", username)
+    assert resp.status_code == 201
+    assert resp.json() == {
+        "moderator_name": username
+    }
+
+
+def test_remove_moderator(api_client):
+    """This should remove a moderator from a channel"""
+    resp = api_client.channels.remove_moderator("a_channel", "01BSRT7XMQT33SCNKTYTSES5QQ")
     assert resp.status_code == 204


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #13 

#### What's this PR do?
Adds functions to add and remove moderators

#### How should this be manually tested?
In a python shell run

    from open_discussions_api.client import OpenDiscussionsApi
    api = OpenDiscussionsApi('terribly_unsafe_default_jwt_secret_key', 'http://localhost:8063/', 'staff_user', roles=['staff']) 
    api.channels.add_moderator('channel_name', 'username_goes_here')

You will need to replace channel_name with your own channel name, staff_user with a reddit user who owns channel_name, the jwt key if you're not using the default one, localhost:8063 with the reddit URL if it's not already localhost, and username_goes_here should be some other reddit user which already exists.
