### PR TITLE
Added "description" field for creating channels

### DIFF
--- a/cassettes/open_discussions_api.channels.client_test.test_create_channel.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_channel.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"title\": \"new test channel\", \"name\": \"examplechannel\", \"public_description\": \"a good channel for all things\", \"channel_type\": \"public\"}"
+          "string": "{\"title\": \"new test channel\", \"name\": \"examplechannel\", \"description\": \"a good channel for all things\", \"public_description\": \"a good channel for all things\", \"channel_type\": \"public\"}"
         },
         "headers": {
           "Accept": [
@@ -36,7 +36,7 @@
       "response": {
         "body": {
           "encoding": null,
-          "string": "{\"title\":\"new test channel\",\"name\":\"examplechannel\",\"public_description\":\"a good channel for all things\",\"channel_type\":\"public\"}"
+          "string": "{\"title\":\"new test channel\",\"name\":\"examplechannel\", \"description\": \"a good channel for all things\",\"public_description\":\"a good channel for all things\",\"channel_type\":\"public\"}"
         },
         "headers": {
           "Allow": [

--- a/cassettes/open_discussions_api.channels.client_test.test_create_private_channel.json
+++ b/cassettes/open_discussions_api.channels.client_test.test_create_private_channel.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"title\": \"new private channel\", \"name\": \"privatechannel\", \"public_description\": \"a good channel for all things\", \"channel_type\": \"private\"}"
+          "string": "{\"title\": \"new private channel\", \"name\": \"privatechannel\", \"description\": \"a good channel for all things\", \"public_description\": \"a good channel for all things\", \"channel_type\": \"private\"}"
         },
         "headers": {
           "Accept": [
@@ -36,7 +36,7 @@
       "response": {
         "body": {
           "encoding": null,
-          "string": "{\"title\":\"new private channel\",\"name\":\"privatechannel\",\"public_description\":\"a good channel for all things\",\"channel_type\":\"private\"}"
+          "string": "{\"title\":\"new private channel\",\"name\":\"privatechannel\", \"description\": \"a good channel for all things\",\"public_description\":\"a good channel for all things\",\"channel_type\":\"private\"}"
         },
         "headers": {
           "Allow": [

--- a/open_discussions_api/base.py
+++ b/open_discussions_api/base.py
@@ -3,7 +3,7 @@
 from urllib.parse import urljoin
 
 
-class BaseApi(object):
+class BaseApi:
     """Base class for APIs"""
     def __init__(self, session, base_url, version):
         self.session = session

--- a/open_discussions_api/channels/client_test.py
+++ b/open_discussions_api/channels/client_test.py
@@ -14,6 +14,7 @@ def test_create_channel(api_client):
     resp = api_client.channels.create(
         title="new test channel",
         name="examplechannel",
+        description="a good channel for all things",
         public_description="a good channel for all things",
         channel_type="public"
     )
@@ -21,12 +22,14 @@ def test_create_channel(api_client):
     assert json.loads(resp.request.body) == {
         "title": "new test channel",
         "name": "examplechannel",
+        "description": "a good channel for all things",
         "public_description": "a good channel for all things",
         "channel_type": "public"
     }
     assert resp.json() == {
         "title": "new test channel",
         "name": "examplechannel",
+        "description": "a good channel for all things",
         "public_description": "a good channel for all things",
         "channel_type": "public"
     }
@@ -37,6 +40,7 @@ def test_create_private_channel(api_client):
     resp = api_client.channels.create(
         title="new private channel",
         name="privatechannel",
+        description="a good channel for all things",
         public_description="a good channel for all things",
         channel_type="private"
     )
@@ -44,12 +48,14 @@ def test_create_private_channel(api_client):
     assert json.loads(resp.request.body) == {
         "title": "new private channel",
         "name": "privatechannel",
+        "description": "a good channel for all things",
         "public_description": "a good channel for all things",
         "channel_type": "private"
     }
     assert resp.json() == {
         "title": "new private channel",
         "name": "privatechannel",
+        "description": "a good channel for all things",
         "public_description": "a good channel for all things",
         "channel_type": "private"
     }
@@ -74,6 +80,7 @@ def test_create_channel_with_bad_channel_type(api_client):
         api_client.channels.create(
             title="new private channel",
             name="privatechannel",
+            description="a good channel for all things",
             public_description="a good channel for all things",
             channel_type="fun"
         )

--- a/open_discussions_api/channels/constants.py
+++ b/open_discussions_api/channels/constants.py
@@ -2,6 +2,7 @@
 CHANNEL_ATTRIBUTES = [
     "title",
     "name",
+    "description",
     "public_description",
     "channel_type",
 ]

--- a/open_discussions_api/client.py
+++ b/open_discussions_api/client.py
@@ -6,7 +6,7 @@ from open_discussions_api.utils import get_token
 from open_discussions_api.channels.client import ChannelsApi
 
 
-class OpenDiscussionsApi(object):
+class OpenDiscussionsApi:
     """
     A client for speaking with open-discussions
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,7 +6,7 @@ ipython
 nplusone
 pdbpp
 pip-tools
-pylint==1.7.1
+pylint==1.7.5
 pytest
 pytest-cov
 pytest-pep8

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+astroid==1.5.3 # fix https://github.com/PyCQA/pylint/issues/1609
 betamax
 betamax_serializers
 codecov


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #22
#### What's this PR do?
Adds the description field to the `create_channel` API.

#### How should this be manually tested?

```python
from open_discussions_api.client import OpenDiscussionsApi

# replace 'mitodl' with your username for OD
api = OpenDiscussionsApi('terribly_unsafe_default_jwt_secret_key','http://localhost:8063/', 'mitodl', roles=['staff'])

api.channels.create(
  title="new test channel",
  name="namenewtestchannel",
  description="markdown",
  public_description="a good channel for all things",
  channel_type="public"
)
```