### PR TITLE
Added email and email_optin fields

### DIFF
--- a/cassettes/open_discussions_api.users.client_test.test_create_user.json
+++ b/cassettes/open_discussions_api.users.client_test.test_create_user.json
@@ -1,11 +1,11 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-08-28T16:20:05",
+      "recorded_at": "2018-01-30T16:19:50",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"profile\": {\"name\": \"my name\", \"image\": \"image1.jpg\", \"image_small\": \"image2.jpg\", \"image_medium\": \"image3.jpg\"}}"
+          "string": "{\"email\": \"user@example.com\", \"profile\": {\"email_optin\": true, \"image_medium\": \"image3.jpg\", \"name\": \"my name\", \"image\": \"image1.jpg\", \"image_small\": \"image2.jpg\"}}"
         },
         "headers": {
           "Accept": [
@@ -15,13 +15,13 @@
             "gzip, deflate"
           ],
           "Authorization": [
-            "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VybmFtZSI6Im1pdG9kbCIsInJvbGVzIjpbInN0YWZmIl0sImV4cCI6MTUwMzk0MDgwNSwib3JpZ19pYXQiOjE1MDM5MzcyMDV9.ChHtJAGoZ4ajfVfaPa5LrYI28eREWJlCjjP5LLfWfYg"
+            "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJyb2xlcyI6WyJzdGFmZiJdLCJvcmlnX2lhdCI6MTUxNzMyOTE4OSwidXNlcm5hbWUiOiJtaXRvZGwiLCJleHAiOjE1MTczMzI3ODl9.xaS02OKD665kS8elK0tcT2hAjvgA59DI_0_QUE3Vfgs"
           ],
           "Connection": [
             "keep-alive"
           ],
           "Content-Length": [
-            "114"
+            "164"
           ],
           "Content-Type": [
             "application/json"
@@ -36,7 +36,7 @@
       "response": {
         "body": {
           "encoding": null,
-          "string": "{\"id\":41,\"username\":\"01BRMT958T3DW02ZAYDG7N6QCB\",\"profile\":{\"name\":\"my name\",\"image\":\"image1.jpg\",\"image_small\":\"image2.jpg\",\"image_medium\":\"image3.jpg\"}}"
+          "string": "{\"id\":127,\"username\":\"01C53XW2FCHQE1PAPHZMH036HF\",\"profile\":{\"name\":\"my name\",\"image\":\"image1.jpg\",\"image_small\":\"image2.jpg\",\"image_medium\":\"image3.jpg\"}}"
         },
         "headers": {
           "Allow": [
@@ -49,7 +49,7 @@
             "application/json"
           ],
           "Date": [
-            "Mon, 28 Aug 2017 16:20:05 GMT"
+            "Tue, 30 Jan 2018 16:19:50 GMT"
           ],
           "Server": [
             "nginx/1.11.6"

--- a/open_discussions_api/conftest.py
+++ b/open_discussions_api/conftest.py
@@ -23,4 +23,4 @@ def use_betamax(mocker, configure_betamax, betamax_recorder):
 @pytest.fixture
 def api_client(use_betamax):
     """API client"""
-    return OpenDiscussionsApi('secret', 'http://localhost:8063/', 'username', roles=[ROLE_STAFF])
+    return OpenDiscussionsApi('secret', 'http://localhost:8063/', 'mitodl', roles=[ROLE_STAFF])

--- a/open_discussions_api/users/client.py
+++ b/open_discussions_api/users/client.py
@@ -3,11 +3,12 @@ from urllib.parse import quote
 
 from open_discussions_api.base import BaseApi
 
-SUPPORTED_USER_ATTRIBUTES = (
+SUPPORTED_PROFILE_ATTRIBUTES = (
     'name',
     'image',
     'image_small',
     'image_medium',
+    'email_optin',
 )
 
 
@@ -35,11 +36,12 @@ class UsersApi(BaseApi):
         """
         return self.session.get(self.get_url("/users/{}/").format(quote(username)))
 
-    def create(self, **profile):
+    def create(self, email=None, profile=None):
         """
         Creates a new user
 
         Args:
+            email (str): the user's email
             profile (dict): attributes used in creating the profile. See SUPPORTED_USER_ATTRIBUTES for a list.
 
         Returns:
@@ -49,15 +51,22 @@ class UsersApi(BaseApi):
             raise AttributeError("No fields provided to create")
 
         for key in profile:
-            if key not in SUPPORTED_USER_ATTRIBUTES:
-                raise AttributeError("Argument {} is not supported".format(key))
+            if key not in SUPPORTED_PROFILE_ATTRIBUTES:
+                raise AttributeError("Profile attribute {} is not supported".format(key))
+
+        payload = {
+            'profile': profile or {},
+        }
+
+        if email is not None:
+            payload['email'] = email
 
         return self.session.post(
             self.get_url("/users/"),
-            json=dict(profile=profile or {})
+            json=payload,
         )
 
-    def update(self, username, **profile):
+    def update(self, username, email=None, profile=None):
         """
         Gets a specific user
 
@@ -73,10 +82,17 @@ class UsersApi(BaseApi):
             raise AttributeError("No fields provided to update")
 
         for key in profile:
-            if key not in SUPPORTED_USER_ATTRIBUTES:
-                raise AttributeError("Argument {} is not supported".format(key))
+            if key not in SUPPORTED_PROFILE_ATTRIBUTES:
+                raise AttributeError("Profile attribute {} is not supported".format(key))
+
+        payload = {
+            'profile': profile or {},
+        }
+
+        if email is not None:
+            payload['email'] = email
 
         return self.session.patch(
             self.get_url("/users/{}/".format(quote(username))),
-            json=dict(profile=profile)
+            json=payload,
         )

--- a/open_discussions_api/users/client_test.py
+++ b/open_discussions_api/users/client_test.py
@@ -24,23 +24,29 @@ def test_list_users(api_client):
 def test_create_user(api_client):
     """Test create user"""
     resp = api_client.users.create(
-        name="my name",
-        image="image1.jpg",
-        image_small="image2.jpg",
-        image_medium="image3.jpg"
+        email='user@example.com',
+        profile=dict(
+            name="my name",
+            image="image1.jpg",
+            image_small="image2.jpg",
+            image_medium="image3.jpg",
+            email_optin=True
+        )
     )
     assert json.loads(resp.request.body) == {
+        "email": "user@example.com",
         "profile": {
             "name": "my name",
             "image": "image1.jpg",
             "image_small": "image2.jpg",
             "image_medium": "image3.jpg",
+            "email_optin": True,
         }
     }
     assert resp.status_code == 201
     assert resp.json() == {
-        "id": 41,
-        "username": "01BRMT958T3DW02ZAYDG7N6QCB",
+        "id": 127,
+        "username": "01C53XW2FCHQE1PAPHZMH036HF",
         "profile": {
             "name": "my name",
             "image": "image1.jpg",
@@ -60,8 +66,8 @@ def test_create_user_no_profile_props(api_client):
 def test_create_user_invalid_profile_props(api_client):
     """Updating with invalid arg raises error"""
     with pytest.raises(AttributeError) as err:
-        api_client.users.create(bad_arg=2)
-    assert str(err.value) == "Argument bad_arg is not supported"
+        api_client.users.create(profile=dict(bad_arg=2))
+    assert str(err.value) == "Profile attribute bad_arg is not supported"
 
 
 def test_get_user(api_client, use_betamax):
@@ -75,14 +81,14 @@ def test_get_user(api_client, use_betamax):
             "name": "my name",
             "image": "image1.jpg",
             "image_small": "image4.jpg",
-            "image_medium": "image3.jpg"
+            "image_medium": "image3.jpg",
         }
     }
 
 
 def test_update_user(api_client):
     """Test patch user"""
-    resp = api_client.users.update("01BRMT958T3DW02ZAYDG7N6QCB", image_small="image4.jpg")
+    resp = api_client.users.update("01BRMT958T3DW02ZAYDG7N6QCB", profile=dict(image_small="image4.jpg"))
     assert json.loads(resp.request.body) == {
         "profile": {
             "image_small": "image4.jpg",
@@ -111,5 +117,5 @@ def test_update_user_no_profile_props(api_client):
 def test_update_user_invalid_profile_props(api_client):
     """Updating with invalid arg raises error"""
     with pytest.raises(AttributeError) as err:
-        api_client.users.update("01BRMT958T3DW02ZAYDG7N6QCB", bad_arg=2)
-    assert str(err.value) == "Argument bad_arg is not supported"
+        api_client.users.update("01BRMT958T3DW02ZAYDG7N6QCB", profile=dict(bad_arg=2))
+    assert str(err.value) == "Profile attribute bad_arg is not supported"


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #26 

#### What's this PR do?
Adds `email` and `profile.email_optin` fields, refactors method args to account for the fact that we now need to pass user values.

#### How should this be manually tested?
Verify that you can create and update a user via the client:


```python
from open_discussions_api.constants import ROLE_STAFF
from open_discussions_api.client import OpenDiscussionsApi

api_client = OpenDiscussionsApi('secret', 'http://localhost:8063/', 'mitodl', roles=[ROLE_STAFF])
data = api_client.users.create(
    email='user@example.com',
    profile=dict(
        name="my name",
        image="image1.jpg",
        image_small="image2.jpg",
        image_medium="image3.jpg",
        email_optin=True
    )
)
assert data.status_code == 201
username = data.json()['username']
```

verify the above user was created and values populated in the DB. Then verify you can still update the profile:
```python
data = api_client.users.update(
    username,
    email='user2@example.com',
    profile=dict(
        name="my name2",
        image="image4.jpg",
        image_small="image5.jpg",
        image_medium="image6.jpg",
        email_optin=False
    )
)
assert data.status_code == 200
```
