### PR TITLE
Added email-optin to user creation process

### DIFF
--- a/cassettes/open_discussions_api.users.client_test.test_create_user.json
+++ b/cassettes/open_discussions_api.users.client_test.test_create_user.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"email\": \"user@example.com\", \"profile\": {\"email_optin\": true, \"image_medium\": \"image3.jpg\", \"name\": \"my name\", \"image\": \"image1.jpg\", \"image_small\": \"image2.jpg\"}}"
+          "string": "{\"email\": \"user@example.com\", \"email_optin\": true, \"profile\": {\"image_medium\": \"image3.jpg\", \"name\": \"my name\", \"image\": \"image1.jpg\", \"image_small\": \"image2.jpg\"}}"
         },
         "headers": {
           "Accept": [

--- a/open_discussions_api/users/client.py
+++ b/open_discussions_api/users/client.py
@@ -36,13 +36,14 @@ class UsersApi(BaseApi):
         """
         return self.session.get(self.get_url("/users/{}/").format(quote(username)))
 
-    def create(self, email=None, profile=None):
+    def create(self, email=None, profile=None, email_optin=False):
         """
         Creates a new user
 
         Args:
             email (str): the user's email
             profile (dict): attributes used in creating the profile. See SUPPORTED_USER_ATTRIBUTES for a list.
+            email_optin (bool): when email_optin is enable.
 
         Returns:
             requests.Response: A response containing the newly created profile data
@@ -56,6 +57,7 @@ class UsersApi(BaseApi):
 
         payload = {
             'profile': profile or {},
+            'email_optin': email_optin,
         }
 
         if email is not None:

--- a/open_discussions_api/users/client_test.py
+++ b/open_discussions_api/users/client_test.py
@@ -23,24 +23,25 @@ def test_list_users(api_client):
 
 def test_create_user(api_client):
     """Test create user"""
+    email_optin = True
     resp = api_client.users.create(
         email='user@example.com',
+        email_optin=email_optin,
         profile=dict(
             name="my name",
             image="image1.jpg",
             image_small="image2.jpg",
-            image_medium="image3.jpg",
-            email_optin=True
+            image_medium="image3.jpg"
         )
     )
     assert json.loads(resp.request.body) == {
         "email": "user@example.com",
+        "email_optin": email_optin,
         "profile": {
             "name": "my name",
             "image": "image1.jpg",
             "image_small": "image2.jpg",
-            "image_medium": "image3.jpg",
-            "email_optin": True,
+            "image_medium": "image3.jpg"
         }
     }
     assert resp.status_code == 201


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/micromasters/issues/3783
required for https://github.com/mitodl/micromasters/pull/3822

#### What's this PR do?
adds `email_optin` flag in user creation.

#### How should this be manually tested?
 run tests

@pdpinch 
