### PR TITLE
Added uid field so open can create social auth objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "3.5"
   - "3.6"
 install: pip install tox
 script: tox -e $(echo py$TRAVIS_PYTHON_VERSION | tr -d .)

--- a/cassettes/open_discussions_api.users.client_test.test_create_user.json
+++ b/cassettes/open_discussions_api.users.client_test.test_create_user.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"email\": \"user@example.com\", \"profile\": {\"email_optin\": true, \"image_medium\": \"image3.jpg\", \"name\": \"my name\", \"image\": \"image1.jpg\", \"image_small\": \"image2.jpg\"}}"
+          "string": "{\"uid\": \"user1\", \"email\": \"user@example.com\", \"profile\": {\"email_optin\": true, \"image_medium\": \"image3.jpg\", \"name\": \"my name\", \"image\": \"image1.jpg\", \"image_small\": \"image2.jpg\"}}"
         },
         "headers": {
           "Accept": [

--- a/cassettes/open_discussions_api.users.client_test.test_update_user.json
+++ b/cassettes/open_discussions_api.users.client_test.test_update_user.json
@@ -5,7 +5,7 @@
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "{\"profile\": {\"image_small\": \"image4.jpg\"}}"
+          "string": "{\"uid\": \"user1\", \"email\": \"user@example.com\", \"profile\": {\"image_small\": \"image4.jpg\"}}"
         },
         "headers": {
           "Accept": [

--- a/open_discussions_api/users/client.py
+++ b/open_discussions_api/users/client.py
@@ -36,11 +36,12 @@ class UsersApi(BaseApi):
         """
         return self.session.get(self.get_url("/users/{}/").format(quote(username)))
 
-    def create(self, email=None, profile=None):
+    def create(self, uid, email=None, profile=None):
         """
         Creates a new user
 
         Args:
+            uid (str): the user's unique identity on the client system
             email (str): the user's email
             profile (dict): attributes used in creating the profile. See SUPPORTED_USER_ATTRIBUTES for a list.
 
@@ -55,6 +56,7 @@ class UsersApi(BaseApi):
                 raise AttributeError("Profile attribute {} is not supported".format(key))
 
         payload = {
+            'uid': uid,
             'profile': profile or {},
         }
 
@@ -66,12 +68,14 @@ class UsersApi(BaseApi):
             json=payload,
         )
 
-    def update(self, username, email=None, profile=None):
+    def update(self, username, uid=None, email=None, profile=None):
         """
         Gets a specific user
 
         Args:
             username (str): The username of the user
+            uid (str): the user's unique identity on the client system
+            email (str): the user's email
             profile (dict):
                 Attributes of the profile to update for that user. See SUPPORTED_USER_ATTRIBUTES for a valid list.
 
@@ -91,6 +95,9 @@ class UsersApi(BaseApi):
 
         if email is not None:
             payload['email'] = email
+
+        if uid is not None:
+            payload['uid'] = uid
 
         return self.session.patch(
             self.get_url("/users/{}/".format(quote(username))),

--- a/open_discussions_api/users/client_test.py
+++ b/open_discussions_api/users/client_test.py
@@ -24,6 +24,7 @@ def test_list_users(api_client):
 def test_create_user(api_client):
     """Test create user"""
     resp = api_client.users.create(
+        'user1',
         email='user@example.com',
         profile=dict(
             name="my name",
@@ -34,6 +35,7 @@ def test_create_user(api_client):
         )
     )
     assert json.loads(resp.request.body) == {
+        "uid": "user1",
         "email": "user@example.com",
         "profile": {
             "name": "my name",
@@ -59,14 +61,14 @@ def test_create_user(api_client):
 def test_create_user_no_profile_props(api_client):
     """Updating with no args raises error"""
     with pytest.raises(AttributeError) as err:
-        api_client.users.create()
+        api_client.users.create('user1')
     assert str(err.value) == "No fields provided to create"
 
 
 def test_create_user_invalid_profile_props(api_client):
     """Updating with invalid arg raises error"""
     with pytest.raises(AttributeError) as err:
-        api_client.users.create(profile=dict(bad_arg=2))
+        api_client.users.create('user1', profile=dict(bad_arg=2))
     assert str(err.value) == "Profile attribute bad_arg is not supported"
 
 
@@ -88,8 +90,15 @@ def test_get_user(api_client, use_betamax):
 
 def test_update_user(api_client):
     """Test patch user"""
-    resp = api_client.users.update("01BRMT958T3DW02ZAYDG7N6QCB", profile=dict(image_small="image4.jpg"))
+    resp = api_client.users.update(
+        "01BRMT958T3DW02ZAYDG7N6QCB",
+        uid='user1',
+        email='user@example.com',
+        profile=dict(image_small="image4.jpg")
+    )
     assert json.loads(resp.request.body) == {
+        "uid": "user1",
+        "email": "user@example.com",
         "profile": {
             "image_small": "image4.jpg",
         }


### PR DESCRIPTION
Requires changes present in the PR https://github.com/mitodl/open-discussions/pull/973

#### What are the relevant tickets?
Fixes #30

#### What's this PR do?
Adds `uid` as a required parameter for user create and optional for user update

#### How should this be manually tested?

create:
```python
from open_discussions_api.constants import ROLE_STAFF
from open_discussions_api.client import OpenDiscussionsApi

api_client = OpenDiscussionsApi('secret', 'http://localhost:8063/', 'mitodl', roles=[ROLE_STAFF])
data = api_client.users.create(
    'user1',
    email='user@example.com',
    profile=dict(
        name="my name",
        image="image1.jpg",
        image_small="image2.jpg",
        image_medium="image3.jpg",
        email_optin=True
    )
)
assert data.status_code == 201
username = data.json()['username']
```
then update:
```python
data = api_client.users.update(
    username,
    email='user2@example.com',
    profile=dict(
        name="my name2",
        image="image4.jpg",
        image_small="image5.jpg",
        image_medium="image6.jpg",
        email_optin=False
    )
)
assert data.status_code == 200
```